### PR TITLE
errgroup add GoWithArgs

### DIFF
--- a/pkg/sync/errgroup/errgroup.go
+++ b/pkg/sync/errgroup/errgroup.go
@@ -41,7 +41,7 @@ func WithCancel(ctx context.Context) *Group {
 	return &Group{ctx: ctx, cancel: cancel}
 }
 
-func (g *Group) do(f func(ctx context.Context,args ...interface{}) error) {
+func (g *Group) do(f func(ctx context.Context) error) {
 	ctx := g.ctx
 	if ctx == nil {
 		ctx = context.Background()
@@ -99,8 +99,6 @@ func (g *Group) Go(f func(ctx context.Context) error) {
 	}
 	go g.do(f)
 }
-
-
 
 func (g *Group) GoWithArgs(f func(ctx context.Context, args ...interface{}) error, args ...interface{}) {
 	g.Go(func(ctx context.Context) error{

--- a/pkg/sync/errgroup/errgroup.go
+++ b/pkg/sync/errgroup/errgroup.go
@@ -41,7 +41,7 @@ func WithCancel(ctx context.Context) *Group {
 	return &Group{ctx: ctx, cancel: cancel}
 }
 
-func (g *Group) do(f func(ctx context.Context) error) {
+func (g *Group) do(f func(ctx context.Context,args ...interface{}) error) {
 	ctx := g.ctx
 	if ctx == nil {
 		ctx = context.Background()
@@ -98,6 +98,14 @@ func (g *Group) Go(f func(ctx context.Context) error) {
 		return
 	}
 	go g.do(f)
+}
+
+
+
+func (g *Group) GoWithArgs(f func(ctx context.Context, args ...interface{}) error, args ...interface{}) {
+	g.Go(func(ctx context.Context) error{
+		return f(ctx, args...)
+	})
 }
 
 // Wait blocks until all function calls from the Go method have returned, then


### PR DESCRIPTION
for 循环中省去一个嵌套
 
`var ids = []int{1,2,3,4}
`
```
//以前
	for _, id := range ids {
		func(id int) {
			group.Go(func(ctx context.Context) error {
				fmt.Println(id)
				return nil
			})
		}(id)
	}

```

```
//之后
	for _, id := range ids {
		group.GoWithArgs(func(ctx context.Context, args ...interface{}) error {
			var (
				id = args[0].(int)
			)
			fmt.Println(id)
			return nil
		}, id)
	}
 
```