### PR TITLE
Optimise log package usage

### DIFF
--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -2,12 +2,14 @@ package log
 
 import (
 	"context"
-	"testing"
-
 	"github.com/bilibili/kratos/pkg/net/metadata"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
+
+func packageInit() {
+
+}
 
 func initStdout() {
 	conf := &Config{
@@ -51,6 +53,12 @@ func testLog(t *testing.T) {
 		Infoc(context.Background(), "keys: %s %s...", "key1", "key2")
 		Infow(context.Background(), "key1", "value1", "key2", "value2")
 	})
+}
+
+func TestPackageInit(t *testing.T) {
+	packageInit()
+	testLog(t)
+	assert.Equal(t, nil, Close())
 }
 
 func TestFile(t *testing.T) {


### PR DESCRIPTION
before you need call log.Init(nil) even if you has no log config
```go
// before
log.Init(nil)
log.Info("I am info log")

// now
log.Info("I am info log too, but don't need to call Init function now")
```