### PR TITLE
make pre-drop thread-safe in bbr

### DIFF
--- a/pkg/ratelimit/bbr/bbr_test.go
+++ b/pkg/ratelimit/bbr/bbr_test.go
@@ -133,7 +133,6 @@ func TestBBRShouldDrop(t *testing.T) {
 		passStat:        passStat,
 		rtStat:          rtStat,
 		winBucketPerSec: 10,
-		prevDrop:        time.Unix(0, 0),
 		conf:            defaultConf,
 	}
 	// cpu >=  800, inflight < maxQps


### PR DESCRIPTION
修复 prev_drop 变量非线程安全的问题 ：

```
(dev_py3) ➜  bbr git:(master) go test -race -test.v -test.run ./
=== RUN   TestBBR
==================
WARNING: DATA RACE
Write at 0x00c00023e2e0 by goroutine 56:
  go-common/library/rate/limit/bbr.(*BBR).Allow()
      /Users/chengfei/Dropbox/workspace/golang/src/go-common/library/rate/limit/bbr/bbr.go:157 +0x110
  go-common/library/rate/limit/bbr.TestBBR.func1()
      /Users/chengfei/Dropbox/workspace/golang/src/go-common/library/rate/limit/bbr/bbr_test.go:33 +0xc4

Previous write at 0x00c00023e2e0 by goroutine 33:
  go-common/library/rate/limit/bbr.(*BBR).Allow()
      /Users/chengfei/Dropbox/workspace/golang/src/go-common/library/rate/limit/bbr/bbr.go:157 +0x110
  go-common/library/rate/limit/bbr.TestBBR.func1()
      /Users/chengfei/Dropbox/workspace/golang/src/go-common/library/rate/limit/bbr/bbr_test.go:33 +0xc4

Goroutine 56 (running) created at:
  go-common/library/rate/limit/bbr.TestBBR()
      /Users/chengfei/Dropbox/workspace/golang/src/go-common/library/rate/limit/bbr/bbr_test.go:30 +0x1d3
  testing.tRunner()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:865 +0x163

Goroutine 33 (running) created at:
  go-common/library/rate/limit/bbr.TestBBR()
      /Users/chengfei/Dropbox/workspace/golang/src/go-common/library/rate/limit/bbr/bbr_test.go:30 +0x1d3
  testing.tRunner()
      /usr/local/Cellar/go/1.12.1/libexec/src/testing/testing.go:865 +0x163
==================
drop:  13502
--- FAIL: TestBBR (15.75s)
    testing.go:809: race detected during execution of test
=== RUN   TestBBRMaxPass
--- PASS: TestBBRMaxPass (1.03s)
=== RUN   TestBBRMinRt
--- PASS: TestBBRMinRt (0.93s)
=== RUN   TestBBRMaxQps
--- PASS: TestBBRMaxQps (0.92s)
=== RUN   TestBBRShouldDrop
--- PASS: TestBBRShouldDrop (0.92s)
=== RUN   TestGroup
=== RUN   TestGroup/get
--- PASS: TestGroup (0.00s)
    --- PASS: TestGroup/get (0.00s)
FAIL
exit status 1
FAIL	go-common/library/rate/limit/bbr	19.606s
```

修复后：

```
(dev_py3) ➜  bbr git:(library/bbr-prev-drop) go test -race -test.v -test.run ./
=== RUN   TestBBR
drop:  15771
--- PASS: TestBBR (15.18s)
=== RUN   TestBBRMaxPass
--- PASS: TestBBRMaxPass (1.03s)
=== RUN   TestBBRMinRt
--- PASS: TestBBRMinRt (0.92s)
=== RUN   TestBBRMaxQps
--- PASS: TestBBRMaxQps (0.92s)
=== RUN   TestBBRShouldDrop
--- PASS: TestBBRShouldDrop (0.93s)
=== RUN   TestGroup
=== RUN   TestGroup/get
--- PASS: TestGroup (0.00s)
    --- PASS: TestGroup/get (0.00s)
PASS
ok  	go-common/library/rate/limit/bbr	20.031s
```

其他事项：
冷却时间从 1s 变更到 1~2s.