### PR TITLE
feat: 创建项目支持 -m 参数，可以自定义 go mod init 时作为参数的 module name

### DIFF
--- a/tool/kratos/main.go
+++ b/tool/kratos/main.go
@@ -35,6 +35,11 @@ func main() {
 					Usage:       "whether to use protobuf for create project",
 					Destination: &p.WithGRPC,
 				},
+				cli.StringFlag{
+					Name:        "m",
+					Usage:       "project module name for create project, for `go mod init`",
+					Destination: &p.ModuleName,
+				},
 			},
 			Action: runNew,
 		},

--- a/tool/kratos/new.go
+++ b/tool/kratos/new.go
@@ -14,6 +14,11 @@ func runNew(ctx *cli.Context) error {
 		return errors.New("required project name")
 	}
 	p.Name = ctx.Args()[0]
+
+	if p.ModuleName == "" {
+		p.ModuleName = path.Join(p.Owner, p.Name)
+	}
+
 	if p.Path != "" {
 		p.Path = path.Join(p.Path, p.Name)
 	} else {
@@ -26,6 +31,7 @@ func runNew(ctx *cli.Context) error {
 	}
 	fmt.Printf("Project: %s\n", p.Name)
 	fmt.Printf("Owner: %s\n", p.Owner)
+	fmt.Printf("Module Name: %s\n", p.ModuleName)
 	fmt.Printf("WithGRPC: %t\n", p.WithGRPC)
 	fmt.Printf("Directory: %s\n\n", p.Path)
 	fmt.Println("The application has been created.")

--- a/tool/kratos/new.go
+++ b/tool/kratos/new.go
@@ -16,7 +16,7 @@ func runNew(ctx *cli.Context) error {
 	p.Name = ctx.Args()[0]
 
 	if p.ModuleName == "" {
-		p.ModuleName = path.Join(p.Owner, p.Name)
+		p.ModuleName = p.Name
 	}
 
 	if p.Path != "" {

--- a/tool/kratos/project.go
+++ b/tool/kratos/project.go
@@ -11,11 +11,12 @@ import (
 
 // project project config
 type project struct {
-	Name     string
-	Owner    string
-	Path     string
-	WithGRPC bool
-	Here     bool
+	Name       string
+	Owner      string
+	Path       string
+	WithGRPC   bool
+	Here       bool
+	ModuleName string // 支持项目的自定义module名 （go.mod init）
 }
 
 const (
@@ -36,6 +37,7 @@ const (
 	_tplTypeModel
 	_tplTypeGRPCServer
 	_tplTypeGomod
+	_tplTypeAPIGogen
 )
 
 var (
@@ -78,6 +80,7 @@ var (
 		_tplTypeHTTPToml:     _tplHTTPToml,
 		_tplTypeModel:        _tplModel,
 		_tplTypeGomod:        _tplGoMod,
+		_tplTypeAPIGogen:     _tplGogen,
 	}
 )
 
@@ -85,6 +88,7 @@ func create() (err error) {
 	if p.WithGRPC {
 		files[_tplTypeGRPCServer] = "/internal/server/grpc/server.go"
 		files[_tplTypeAPIProto] = "/api/api.proto"
+		files[_tplTypeAPIGogen] = "/api/generate.go"
 		tpls[_tplTypeHTTPServer] = _tplPBHTTPServer
 		tpls[_tplTypeGRPCServer] = _tplGRPCServer
 		tpls[_tplTypeGRPCToml] = _tplGRPCToml

--- a/tool/kratos/template.go
+++ b/tool/kratos/template.go
@@ -72,8 +72,8 @@ import (
 	"syscall"
 	"time"
 
-	"{{.Name}}/internal/server/http"
-	"{{.Name}}/internal/service"
+	"{{.ModuleName}}/internal/server/http"
+	"{{.ModuleName}}/internal/service"
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 	"github.com/bilibili/kratos/pkg/log"
 )
@@ -122,9 +122,9 @@ import (
 	"syscall"
 	"time"
 
-	"{{.Name}}/internal/server/grpc"
-	"{{.Name}}/internal/server/http"
-	"{{.Name}}/internal/service"
+	"{{.ModuleName}}/internal/server/grpc"
+	"{{.ModuleName}}/internal/server/http"
+	"{{.ModuleName}}/internal/service"
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 	"github.com/bilibili/kratos/pkg/log"
 )
@@ -284,7 +284,7 @@ func (d *dao) pingRedis(ctx context.Context) (err error) {
 import (
 	"context"
 
-	"{{.Name}}/internal/dao"
+	"{{.ModuleName}}/internal/dao"
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 )
 
@@ -324,8 +324,8 @@ import (
 	"context"
 	"fmt"
 
-	pb "{{.Name}}/api"
-	"{{.Name}}/internal/dao"
+	pb "{{.ModuleName}}/api"
+	"{{.ModuleName}}/internal/dao"
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -381,8 +381,8 @@ func (s *Service) Close() {
 import (
 	"net/http"
 
-	"{{.Name}}/internal/model"
-	"{{.Name}}/internal/service"
+	"{{.ModuleName}}/internal/model"
+	"{{.ModuleName}}/internal/service"
 
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 	"github.com/bilibili/kratos/pkg/log"
@@ -442,9 +442,9 @@ func howToStart(c *bm.Context) {
 import (
 	"net/http"
 
-	pb "{{.Name}}/api"
-	"{{.Name}}/internal/model"
-	"{{.Name}}/internal/service"
+	pb "{{.ModuleName}}/api"
+	"{{.ModuleName}}/internal/model"
+	"{{.ModuleName}}/internal/service"
 
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 	"github.com/bilibili/kratos/pkg/log"
@@ -542,7 +542,7 @@ message HelloResp {
 type Kratos struct {
 	Hello string
 }`
-	_tplGoMod = `module {{.Name}}
+	_tplGoMod = `module {{.ModuleName}}
 
 go 1.12
 
@@ -573,8 +573,8 @@ replace (
 	_tplGRPCServer = `package grpc
 
 import (
-	pb "{{.Name}}/api"
-	"{{.Name}}/internal/service"
+	pb "{{.ModuleName}}/api"
+	"{{.ModuleName}}/internal/service"
 	"github.com/bilibili/kratos/pkg/conf/paladin"
 	"github.com/bilibili/kratos/pkg/net/rpc/warden"
 )
@@ -597,5 +597,9 @@ func New(svc *service.Service) *warden.Server {
 	}
 	return ws
 }
+`
+	_tplGogen = `package api
+
+//go:generate kratos tool protoc --swagger --grpc --bm api.proto
 `
 )


### PR DESCRIPTION
feat: 
1. 创建项目如果带有proto参数，在api目录放置一个go generate
2. 创建项目支持 -m 参数，可以自定义 go mod init 时作为参数的 module name，
    2.1 module name 规则：有指定 module name时使用指定的输入，否则尝试使用 path.Join(Owner, Name)
    2.2 相关的 tpl 里所有import 语句，将{{.Name}}替换成 {{.ModuleName}}