### PR TITLE
fix: proto2swagger support same path different method (close #191)

### DIFF
--- a/tool/protobuf/protoc-gen-bswagger/generator.go
+++ b/tool/protobuf/protoc-gen-bswagger/generator.go
@@ -74,7 +74,9 @@ func (t *swaggerGen) generateSwagger(file *descriptor.FileDescriptorProto) *plug
 			}
 			apiInfo := t.GetHttpInfoCached(file, svc, meth)
 			pathItem := swaggerPathItemObject{}
-
+			if originPathItem,ok := swaggerObj.Paths[apiInfo.Path];ok{
+				pathItem= originPathItem
+			}
 			op := t.getOperationByHTTPMethod(apiInfo.HttpMethod, &pathItem)
 			op.Summary = apiInfo.Title
 			op.Description = apiInfo.Description

--- a/tool/protobuf/protoc-gen-bswagger/generator.go
+++ b/tool/protobuf/protoc-gen-bswagger/generator.go
@@ -74,8 +74,8 @@ func (t *swaggerGen) generateSwagger(file *descriptor.FileDescriptorProto) *plug
 			}
 			apiInfo := t.GetHttpInfoCached(file, svc, meth)
 			pathItem := swaggerPathItemObject{}
-			if originPathItem,ok := swaggerObj.Paths[apiInfo.Path];ok{
-				pathItem= originPathItem
+			if originPathItem, ok := swaggerObj.Paths[apiInfo.Path]; ok {
+				pathItem = originPathItem
 			}
 			op := t.getOperationByHTTPMethod(apiInfo.HttpMethod, &pathItem)
 			op.Summary = apiInfo.Title


### PR DESCRIPTION
  ```
  rpc methoda(Empty) returns (Empty) {
        option (google.api.http) = {
            post:"/same/path"
        };
    };
    rpc methodb(Empty) returns (Empty) {
        option (google.api.http) = {
            get:"/same/path"
        };
    };
```
proto2swagger support same path different method