### PR TITLE
修复自适应限流在 cpu 抖动后，可能出现限流过激的问题

### DIFF
--- a/pkg/ratelimit/bbr/bbr_test.go
+++ b/pkg/ratelimit/bbr/bbr_test.go
@@ -145,7 +145,13 @@ func TestBBRShouldDrop(t *testing.T) {
 	bbr.inFlight = 80
 	assert.Equal(t, true, bbr.shouldDrop())
 
+	// cpu < 800, inflight > maxQps, cold duration
+	cpu = 700
+	bbr.inFlight = 80
+	assert.Equal(t, true, bbr.shouldDrop())
+ 
 	// cpu < 800, inflight > maxQps
+	time.Sleep(2 * time.Second)
 	cpu = 700
 	bbr.inFlight = 80
 	assert.Equal(t, false, bbr.shouldDrop())


### PR DESCRIPTION
背景

自适应限流在 cpu 抖动后，可能造成限流过激。

触发场景：

1. cpu 抖动
2. 接口流量稳定不变
3. 接口并发随机

![image](https://user-images.githubusercontent.com/10752787/60510354-cb215c00-9d01-11e9-990d-bec1017b01b0.png)
