### PR TITLE
fix redis option order

### DIFF
--- a/pkg/cache/redis/pool.go
+++ b/pkg/cache/redis/pool.go
@@ -61,12 +61,12 @@ func NewPool(c *Config, options ...DialOption) (p *Pool) {
 	if c.DialTimeout <= 0 || c.ReadTimeout <= 0 || c.WriteTimeout <= 0 {
 		panic("must config redis timeout")
 	}
-	var ops []DialOption
-	cnop := DialConnectTimeout(time.Duration(c.DialTimeout))
-	rdop := DialReadTimeout(time.Duration(c.ReadTimeout))
-	wrop := DialWriteTimeout(time.Duration(c.WriteTimeout))
-	auop := DialPassword(c.Auth)
-	ops = append(ops, cnop, rdop, wrop, auop)
+	ops := []DialOption{
+		DialConnectTimeout(time.Duration(c.DialTimeout)),
+		DialReadTimeout(time.Duration(c.ReadTimeout)),
+		DialWriteTimeout(time.Duration(c.WriteTimeout)),
+		DialPassword(c.Auth),
+	}
 	ops = append(ops, options...)
 	p1 := pool.NewSlice(c.Config)
 	p1.New = func(ctx context.Context) (io.Closer, error) {

--- a/pkg/cache/redis/pool.go
+++ b/pkg/cache/redis/pool.go
@@ -61,18 +61,16 @@ func NewPool(c *Config, options ...DialOption) (p *Pool) {
 	if c.DialTimeout <= 0 || c.ReadTimeout <= 0 || c.WriteTimeout <= 0 {
 		panic("must config redis timeout")
 	}
-	p1 := pool.NewSlice(c.Config)
+	var ops []DialOption
 	cnop := DialConnectTimeout(time.Duration(c.DialTimeout))
-	options = append(options, cnop)
 	rdop := DialReadTimeout(time.Duration(c.ReadTimeout))
-	options = append(options, rdop)
 	wrop := DialWriteTimeout(time.Duration(c.WriteTimeout))
-	options = append(options, wrop)
 	auop := DialPassword(c.Auth)
-	options = append(options, auop)
-	// new pool
+	ops = append(ops, cnop, rdop, wrop, auop)
+	ops = append(ops, options...)
+	p1 := pool.NewSlice(c.Config)
 	p1.New = func(ctx context.Context) (io.Closer, error) {
-		conn, err := Dial(c.Proto, c.Addr, options...)
+		conn, err := Dial(c.Proto, c.Addr, ops...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
自定义的 option 需要支持覆盖任何默认的 option，所以参数中的 options 要放到后面，不然会出现无法覆盖的情况，比如，使用 DialNetDial() 无法覆盖 DialConnectTimeout()