### PR TITLE
perfermance:  reduce calculation times of maxInflight

### DIFF
--- a/pkg/ratelimit/bbr/bbr.go
+++ b/pkg/ratelimit/bbr/bbr.go
@@ -18,6 +18,7 @@ import (
 var (
 	cpu         int64
 	decay       = 0.95
+	initTime    = time.Now()
 	defaultConf = &Config{
 		Window:       time.Second * 10,
 		WinBucket:    100,
@@ -72,6 +73,9 @@ type BBR struct {
 	winBucketPerSec int64
 	conf            *Config
 	prevDrop        atomic.Value
+	prevDropHit     int32
+	rawMaxPASS      int64
+	rawMinRt        int64
 }
 
 // Config contains configs of bbr limiter.
@@ -85,9 +89,13 @@ type Config struct {
 }
 
 func (l *BBR) maxPASS() int64 {
-	val := int64(l.passStat.Reduce(func(iterator metric.Iterator) float64 {
+	rawMaxPass := atomic.LoadInt64(&l.rawMaxPASS)
+	if rawMaxPass > 0 && l.passStat.Timespan() < 1 {
+		return rawMaxPass
+	}
+	rawMaxPass = int64(l.passStat.Reduce(func(iterator metric.Iterator) float64 {
 		var result = 1.0
-		for iterator.Next() {
+		for i := 1; iterator.Next() && i < l.conf.WinBucket; i++ {
 			bucket := iterator.Bucket()
 			count := 0.0
 			for _, p := range bucket.Points {
@@ -97,16 +105,21 @@ func (l *BBR) maxPASS() int64 {
 		}
 		return result
 	}))
-	if val == 0 {
-		return 1
+	if rawMaxPass == 0 {
+		rawMaxPass = 1
 	}
-	return val
+	atomic.StoreInt64(&l.rawMaxPASS, rawMaxPass)
+	return rawMaxPass
 }
 
 func (l *BBR) minRT() int64 {
-	val := l.rtStat.Reduce(func(iterator metric.Iterator) float64 {
+	rawMinRT := atomic.LoadInt64(&l.rawMinRt)
+	if rawMinRT > 0 && l.rtStat.Timespan() < 1 {
+		return rawMinRT
+	}
+	rawMinRT = int64(math.Ceil(l.rtStat.Reduce(func(iterator metric.Iterator) float64 {
 		var result = math.MaxFloat64
-		for iterator.Next() {
+		for i := 1; iterator.Next() && i < l.conf.WinBucket; i++ {
 			bucket := iterator.Bucket()
 			if len(bucket.Points) == 0 {
 				continue
@@ -119,8 +132,12 @@ func (l *BBR) minRT() int64 {
 			result = math.Min(result, avg)
 		}
 		return result
-	})
-	return int64(math.Ceil(val))
+	})))
+	if rawMinRT <= 0 {
+		rawMinRT = 1
+	}
+	atomic.StoreInt64(&l.rawMinRt, rawMinRT)
+	return rawMinRT
 }
 
 func (l *BBR) maxFlight() int64 {
@@ -129,20 +146,28 @@ func (l *BBR) maxFlight() int64 {
 
 func (l *BBR) shouldDrop() bool {
 	if l.cpu() < l.conf.CPUThreshold {
-		prevDrop, ok := l.prevDrop.Load().(time.Time)
-		if !ok {
+		prevDrop, _ := l.prevDrop.Load().(time.Duration)
+		if prevDrop == 0 {
 			return false
 		}
-		if time.Since(prevDrop) <= time.Second {
+		if time.Since(initTime)-prevDrop <= time.Second {
+			if atomic.LoadInt32(&l.prevDropHit) == 0 {
+				atomic.StoreInt32(&l.prevDropHit, 1)
+			}
 			inFlight := atomic.LoadInt64(&l.inFlight)
 			return inFlight > 1 && inFlight > l.maxFlight()
 		}
+		l.prevDrop.Store(time.Duration(0))
 		return false
 	}
 	inFlight := atomic.LoadInt64(&l.inFlight)
 	drop := inFlight > 1 && inFlight > l.maxFlight()
 	if drop {
-		l.prevDrop.Store(time.Now())
+		prevDrop, _ := l.prevDrop.Load().(time.Duration)
+		if prevDrop != 0 {
+			return drop
+		}
+		l.prevDrop.Store(time.Since(initTime))
 	}
 	return drop
 }
@@ -169,9 +194,9 @@ func (l *BBR) Allow(ctx context.Context, opts ...limit.AllowOption) (func(info l
 		return nil, ecode.LimitExceed
 	}
 	atomic.AddInt64(&l.inFlight, 1)
-	stime := time.Now()
+	stime := time.Since(initTime)
 	return func(do limit.DoneInfo) {
-		rt := int64(time.Since(stime) / time.Millisecond)
+		rt := int64((time.Since(initTime) - stime) / time.Millisecond)
 		l.rtStat.Add(rt)
 		atomic.AddInt64(&l.inFlight, -1)
 		switch do.Op {

--- a/pkg/ratelimit/bbr/bbr_test.go
+++ b/pkg/ratelimit/bbr/bbr_test.go
@@ -171,7 +171,7 @@ func TestGroup(t *testing.T) {
 
 func BenchmarkBBRAllowUnderLowLoad(b *testing.B) {
 	cpuGetter := func() int64 {
-		return 50
+		return 500
 	}
 	bucketDuration := time.Millisecond * 100
 	passStat := metric.NewRollingCounter(metric.RollingCounterOpts{Size: 10, BucketDuration: bucketDuration})
@@ -194,7 +194,7 @@ func BenchmarkBBRAllowUnderLowLoad(b *testing.B) {
 
 func BenchmarkBBRAllowUnderHighLoad(b *testing.B) {
 	cpuGetter := func() int64 {
-		return 90
+		return 900
 	}
 	bucketDuration := time.Millisecond * 100
 	passStat := metric.NewRollingCounter(metric.RollingCounterOpts{Size: 10, BucketDuration: bucketDuration})
@@ -217,7 +217,7 @@ func BenchmarkBBRAllowUnderHighLoad(b *testing.B) {
 
 func BenchmarkBBRShouldDropUnderLowLoad(b *testing.B) {
 	cpuGetter := func() int64 {
-		return 50
+		return 500
 	}
 	bucketDuration := time.Millisecond * 100
 	passStat := metric.NewRollingCounter(metric.RollingCounterOpts{Size: 10, BucketDuration: bucketDuration})
@@ -244,7 +244,7 @@ func BenchmarkBBRShouldDropUnderLowLoad(b *testing.B) {
 
 func BenchmarkBBRShouldDropUnderHighLoad(b *testing.B) {
 	cpuGetter := func() int64 {
-		return 90
+		return 900
 	}
 	bucketDuration := time.Millisecond * 100
 	passStat := metric.NewRollingCounter(metric.RollingCounterOpts{Size: 10, BucketDuration: bucketDuration})

--- a/pkg/stat/metric/rolling_counter.go
+++ b/pkg/stat/metric/rolling_counter.go
@@ -13,6 +13,7 @@ var _ Aggregation = &rollingCounter{}
 type RollingCounter interface {
 	Metric
 	Aggregation
+	Timespan() int
 	// Reduce applies the reduction function to all buckets within the window.
 	Reduce(func(Iterator) float64) float64
 }
@@ -65,4 +66,8 @@ func (r *rollingCounter) Sum() float64 {
 
 func (r *rollingCounter) Value() int64 {
 	return int64(r.Sum())
+}
+
+func (r *rollingCounter) Timespan() int {
+	return r.policy.timespan()
 }


### PR DESCRIPTION
##  changelog

1. rtStat 使用 rolling counter
2. preDrop 使用 atomic.Value 以利用 monotonic time
3. 修改 hotpath，减少 cpu 计算
4. rollingCounter，当前采样点不纳入统计中
5. 缓存 maxPass & minRt，检查计算
6. prevDrop 使用 duration，以利用 monotonic time

## benchmark

优化前：

``` bash
BenchmarkBBRAllowUnderLowLoad-8         	  200000	     30084 ns/op
BenchmarkBBRAllowUnderHighLoad-8        	  200000	     30315 ns/op
BenchmarkBBRShouldDropUnderLowLoad-8    	 2000000	       572 ns/op
BenchmarkBBRShouldDropUnderHighLoad-8   	 2000000	       570 ns/op
```

优化后：

~~BenchmarkBBRAllowUnderLowLoad-8         	 3000000	       465 ns/op
BenchmarkBBRAllowUnderHighLoad-8        	 3000000	       468 ns/op
BenchmarkBBRShouldDropUnderLowLoad-8    	200000000	         6.35 ns/op
BenchmarkBBRShouldDropUnderHighLoad-8   	200000000	         6.86 ns/op~~


``` bash
BenchmarkBBRAllowUnderLowLoad-8             	 5000000	       377 ns/op
BenchmarkBBRAllowUnderHighLoad-8            	 5000000	       380 ns/op
BenchmarkBBRShouldDropUnderLowLoad-8        	200000000	         6.40 ns/op
BenchmarkBBRShouldDropUnderHighLoad-8       	 3000000	       476 ns/op
BenchmarkBBRShouldDropUnderUnstableLoad-8   	 2000000	       500 ns/op
```

