### PR TITLE
update kratos version

### DIFF
--- a/tool/kratos/template.go
+++ b/tool/kratos/template.go
@@ -547,27 +547,11 @@ type Kratos struct {
 go 1.12
 
 require (
-	github.com/bilibili/kratos v0.2.0
+	github.com/bilibili/kratos v0.2.1
 	github.com/gogo/protobuf v1.2.1
-	github.com/golang/protobuf v1.3.1
-	golang.org/x/net v0.0.0-20190420063019-afa5a82059c6
-	google.golang.org/grpc v1.20.1
-)
-
-replace (
-	cloud.google.com/go => github.com/googleapis/google-cloud-go v0.26.0
-	golang.org/x/crypto => github.com/golang/crypto v0.0.0-20190123085648-057139ce5d2b
-	golang.org/x/lint => github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3
-	golang.org/x/net => github.com/golang/net v0.0.0-20190420063019-afa5a82059c6
-	golang.org/x/oauth2 => github.com/golang/oauth2 v0.0.0-20180821212333-d2e6202438be
-	golang.org/x/sync => github.com/golang/sync v0.0.0-20181108010431-42b317875d0f
-	golang.org/x/sys => github.com/golang/sys v0.0.0-20180905080454-ebe1bf3edb33
-	golang.org/x/text => github.com/golang/text v0.3.0
-	golang.org/x/time => github.com/golang/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/tools => github.com/golang/tools v0.0.0-20190328211700-ab21143f2384
-	google.golang.org/appengine => github.com/golang/appengine v1.1.0
-	google.golang.org/genproto => github.com/google/go-genproto v0.0.0-20180817151627-c66870c02cf8
-	google.golang.org/grpc => github.com/grpc/grpc-go v1.20.1
+	github.com/golang/protobuf v1.3.2
+	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
+	google.golang.org/grpc v1.22.0
 )
 `
 	_tplGRPCServer = `package grpc

--- a/tool/kratos/version.go
+++ b/tool/kratos/version.go
@@ -8,9 +8,9 @@ import (
 
 var (
 	// Version is version
-	Version = "0.3.0"
+	Version = "0.2.1"
 	// BuildTime is BuildTime
-	BuildTime = "2019/07/19"
+	BuildTime = "2019/07/24"
 )
 
 // VersionOptions include version


### PR DESCRIPTION
v0.2.1
Added:
1、prometheus监控模版化；
2、warden grpc默认注册direct协议；
Fixed:
1、修复discovery每隔30s进行switch node；
2、修复ectd package引入不对；
3、去除go mod replace，解决可能会出现编译失败；