### PR TITLE
update kratos to v0.2.2

### DIFF
--- a/tool/kratos/template.go
+++ b/tool/kratos/template.go
@@ -546,7 +546,7 @@ type Kratos struct {
 go 1.12
 
 require (
-	github.com/bilibili/kratos v0.2.1
+	github.com/bilibili/kratos v0.2.2
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.2
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7

--- a/tool/kratos/version.go
+++ b/tool/kratos/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is version
-	Version = "0.2.1"
+	Version = "0.2.2"
 	// BuildTime is BuildTime
 	BuildTime = "2019/07/24"
 )


### PR DESCRIPTION
v0.2.2
Added:
1、添加doc和example用例文档；
2、添加ecode proto生成工具；
3、添加prometheus dashboards监控统计模板；
4、bm generator支持默认grpc path生成；
Fixed:
1、修复BM注册404、405 handle；
2、修复warden resolver集群过虑bug；
3、修复DB trace的ip信息；
4、修复获取网卡IP对状态判断；
5、修复zipkin trace信息不完整；