### PR TITLE
protect slice bounds not out of range

### DIFF
--- a/pkg/net/http/blademaster/logger.go
+++ b/pkg/net/http/blademaster/logger.go
@@ -34,8 +34,10 @@ func Logger() HandlerFunc {
 			caller = noUser
 		}
 
-		_metricServerReqCodeTotal.Inc(c.RoutePath[1:], caller, strconv.FormatInt(int64(cerr.Code()), 10))
-		_metricServerReqDur.Observe(int64(dt/time.Millisecond), c.RoutePath[1:], caller)
+		if len(c.RoutePath) > 0 {
+			_metricServerReqCodeTotal.Inc(c.RoutePath[1:], caller, strconv.FormatInt(int64(cerr.Code()), 10))
+			_metricServerReqDur.Observe(int64(dt/time.Millisecond), c.RoutePath[1:], caller)
+		}
 
 		lf := log.Infov
 		errmsg := ""


### PR DESCRIPTION
按照`quickstart`运行时，发现如果请求一个路由中不存在的地址，`goroutine` 中会报 `panic`，如图：
![image](https://note.youdao.com/yws/api/personal/file/WEB0bee9ca03452265c4e1af939713199cd?method=download&shareKey=853eeb0808a495c059a6f959425ddc67)


追踪后发现，是`logger`中间件中处理字符串切片时，缺少一个字符串为空的条件判断。正常注册的路由 `c.RoutePath` 不会为空，但是通过诸如 `engine.NoRoute(),engine.NoMethod()`等方式注册的 `handler`中， `c.RoutePath` 是空字符串