### PR TITLE
Remove GRPC Toml generate

### DIFF
--- a/tool/kratos/project.go
+++ b/tool/kratos/project.go
@@ -33,7 +33,6 @@ const (
 	_tplTypeMCToml
 	_tplTypeRedisToml
 	_tplTypeHTTPToml
-	_tplTypeGRPCToml
 	_tplTypeModel
 	_tplTypeGRPCServer
 	_tplTypeGomod
@@ -61,7 +60,6 @@ var (
 		_tplTypeMCToml:    "/configs/memcache.toml",
 		_tplTypeRedisToml: "/configs/redis.toml",
 		_tplTypeHTTPToml:  "/configs/http.toml",
-		_tplTypeGRPCToml:  "/configs/grpc.toml",
 	}
 	// tpls type => content
 	tpls = map[int]string{
@@ -91,7 +89,6 @@ func create() (err error) {
 		files[_tplTypeAPIGogen] = "/api/generate.go"
 		tpls[_tplTypeHTTPServer] = _tplPBHTTPServer
 		tpls[_tplTypeGRPCServer] = _tplGRPCServer
-		tpls[_tplTypeGRPCToml] = _tplGRPCToml
 		tpls[_tplTypeService] = _tplGPRCService
 		tpls[_tplTypeMain] = _tplGRPCMain
 	}

--- a/tool/kratos/template.go
+++ b/tool/kratos/template.go
@@ -51,11 +51,6 @@ demoExpire = "24h"
     addr = "0.0.0.0:8000"
     timeout = "1s"
 `
-	_tplGRPCToml = `
-[server]
-    addr = "0.0.0.0:9000"
-    timeout = "1s"
-`
 
 	_tplChangeLog = `## {{.Name}}
 
@@ -564,15 +559,7 @@ import (
 
 // New new a grpc server.
 func New(svc *service.Service) *warden.Server {
-	var rc struct {
-		Server *warden.ServerConfig
-	}
-	if err := paladin.Get("grpc.toml").UnmarshalTOML(&rc); err != nil {
-		if err != paladin.ErrNotExist {
-			panic(err)
-		}
-	}
-	ws := warden.NewServer(rc.Server)
+	ws := warden.NewServer(nil)
 	pb.RegisterDemoServer(ws.Server(), svc)
 	ws, err := ws.Start()
 	if err != nil {


### PR DESCRIPTION
Since now warden use a environment variable dsn to configure. The toml config is deprecated and should not be generated in new project.