### PR TITLE
gopath compatible with windows

### DIFF
--- a/tool/kratos-protoc/protoc.go
+++ b/tool/kratos-protoc/protoc.go
@@ -144,7 +144,15 @@ func latestKratos() (string, error) {
 }
 
 func gopath() (gp string) {
-	gopaths := strings.Split(os.Getenv("GOPATH"), ":")
+	var gopaths []string
+
+	switch runtime.GOOS {
+	case "windows":
+		gopaths = strings.Split(os.Getenv("GOPATH"), ";")
+	default:
+		gopaths = strings.Split(os.Getenv("GOPATH"), ":")
+	}
+
 	if len(gopaths) == 1 && gopaths[0] != "" {
 		return gopaths[0]
 	}

--- a/tool/kratos/tool.go
+++ b/tool/kratos/tool.go
@@ -186,7 +186,15 @@ func (t Tool) installed() bool {
 }
 
 func gopath() (gp string) {
-	gopaths := strings.Split(os.Getenv("GOPATH"), ":")
+	var gopaths []string
+
+	switch runtime.GOOS {
+	case "windows":
+		gopaths = strings.Split(os.Getenv("GOPATH"), ";")
+	default:
+		gopaths = strings.Split(os.Getenv("GOPATH"), ":")
+	}
+
 	if len(gopaths) == 1 && gopaths[0] != "" {
 		return gopaths[0]
 	}


### PR DESCRIPTION
您好，感谢在issues#344的邀请，我提交了这个pr。
原因如issues#344中描述，windows中gopath用分号隔开，我照着tool/kratos-protoc/protoc.go中的checkProtoc()方法里面的内容改了一下，"windows"字符串从tool\kratos\tool_index.go中取得。
测试以后在windows中能够运行。解决了我在issues#344中的问题。
我还在tool/kratos/tool.go中找到相同的gopath获取方式，也一起改了，但不知道对windows有什么影响。
再次感谢您的邀请。