### PR TITLE
解决k8s configmap生成的 ..data 软链接目录被识别成文件的问题

### DIFF
--- a/pkg/conf/paladin/file.go
+++ b/pkg/conf/paladin/file.go
@@ -167,7 +167,7 @@ func loadValues(base string) (map[string]*Value, error) {
 			return nil, fmt.Errorf("paladin: read dir %s error: %s", base, err)
 		}
 		for _, file := range files {
-			if !file.IsDir() {
+			if !file.IsDir() && (file.Mode()&os.ModeSymlink) != os.ModeSymlink {
 				paths = append(paths, path.Join(base, file.Name()))
 			}
 		}


### PR DESCRIPTION
由于 pkg/conf/paladin/file.go Line: 165 使用了ioutil.ReadDir来读取目录下文件，而底层使用的是LStat，所以遇到目录的软链接会导致 Line: 170 的 file.IsDir()为false，所以加个判断

fix #355 