### PR TITLE
opt last append time of rolling policy

### DIFF
--- a/pkg/stat/metric/rolling_policy.go
+++ b/pkg/stat/metric/rolling_policy.go
@@ -38,7 +38,7 @@ func NewRollingPolicy(window *Window, opts RollingPolicyOpts) *RollingPolicy {
 
 func (r *RollingPolicy) timespan() int {
 	v := int(time.Since(r.lastAppendTime) / r.bucketDuration)
-	if v < r.size && v > -1 { // maybe time backwards
+	if v > -1 { // maybe time backwards
 		return v
 	}
 	return r.size
@@ -48,9 +48,13 @@ func (r *RollingPolicy) add(f func(offset int, val float64), val float64) {
 	r.mu.Lock()
 	timespan := r.timespan()
 	if timespan > 0 {
+		r.lastAppendTime = r.lastAppendTime.Add(time.Duration(timespan * int(r.bucketDuration)))
 		offset := r.offset
 		// reset the expired buckets
 		s := offset + 1
+		if timespan > r.size {
+			timespan = r.size
+		}
 		e, e1 := s+timespan, 0 // e: reset offset must start from offset+1
 		if e > r.size {
 			e1 = e - r.size
@@ -65,7 +69,6 @@ func (r *RollingPolicy) add(f func(offset int, val float64), val float64) {
 			offset = i
 		}
 		r.offset = offset
-		r.lastAppendTime = r.lastAppendTime.Add(time.Duration(timespan * int(r.bucketDuration)))
 	}
 	f(r.offset, val)
 	r.mu.Unlock()

--- a/pkg/stat/metric/rolling_policy.go
+++ b/pkg/stat/metric/rolling_policy.go
@@ -65,7 +65,7 @@ func (r *RollingPolicy) add(f func(offset int, val float64), val float64) {
 			offset = i
 		}
 		r.offset = offset
-		r.lastAppendTime = time.Now()
+		r.lastAppendTime = r.lastAppendTime.Add(time.Duration(timespan * int(r.bucketDuration)))
 	}
 	f(r.offset, val)
 	r.mu.Unlock()

--- a/pkg/stat/metric/rolling_policy_test.go
+++ b/pkg/stat/metric/rolling_policy_test.go
@@ -24,12 +24,8 @@ func Handler(t *testing.T, table []map[string][]int) {
 			policy.Add(1)
 			offset, points := offsetAndPoints[2*i], offsetAndPoints[2*i+1]
 
-			for _, b := range policy.window.window {
-				fmt.Println(b.Points)
-			}
-
 			if int(policy.window.window[offset].Points[0]) != points {
-				t.Errorf("error, time since last append: %v, last offset: %v", totalTs, lastOffset)
+				t.Errorf("error, time since last append: %vms, last offset: %v", totalTs, lastOffset)
 			}
 			lastOffset = offset
 		}
@@ -39,15 +35,24 @@ func Handler(t *testing.T, table []map[string][]int) {
 func TestRollingPolicy_Add(t *testing.T) {
 	rand.Seed(time.Now().Unix())
 
+	// test add after 400ms and 601ms relative to the policy created time
+	policy := GetRollingPolicy()
+	time.Sleep(400 * time.Millisecond)
+	policy.Add(1)
+	time.Sleep(201 * time.Millisecond)
+	policy.Add(1)
+	for _, b := range policy.window.window {
+		fmt.Println(b.Points)
+	}
+	if int(policy.window.window[1].Points[0]) != 1 {
+		t.Errorf("error, time since last append: %vms, last offset: %v", 300, 0)
+	}
+	if int(policy.window.window[2].Points[0]) != 1 {
+		t.Errorf("error, time since last append: %vms, last offset: %v", 301, 0)
+	}
+
+	// test func timespan return real span
 	table := []map[string][]int{
-		{
-			"timeSleep":       []int{299, 2},
-			"offsetAndPoints": []int{0, 1, 1, 1},
-		},
-		{
-			"timeSleep":       []int{294, 7, 600},
-			"offsetAndPoints": []int{0, 1, 1, 1, 3, 1},
-		},
 		{
 			"timeSleep":       []int{294, 3200},
 			"offsetAndPoints": []int{0, 1, 0, 1},

--- a/pkg/stat/metric/rolling_policy_test.go
+++ b/pkg/stat/metric/rolling_policy_test.go
@@ -1,0 +1,62 @@
+package metric
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func GetRollingPolicy() *RollingPolicy {
+	w := NewWindow(WindowOpts{Size: 10})
+	return NewRollingPolicy(w, RollingPolicyOpts{BucketDuration: 300 * time.Millisecond})
+}
+
+func Handler(t *testing.T, table []map[string][]int) {
+	for _, hm := range table {
+		var totalTs, lastOffset int
+		offsetAndPoints := hm["offsetAndPoints"]
+		timeSleep := hm["timeSleep"]
+		policy := GetRollingPolicy()
+		for i, n := range timeSleep {
+			totalTs += n
+			time.Sleep(time.Duration(n) * time.Millisecond)
+			policy.Add(1)
+			offset, points := offsetAndPoints[2*i], offsetAndPoints[2*i+1]
+
+			for _, b := range policy.window.window {
+				fmt.Println(b.Points)
+			}
+
+			if int(policy.window.window[offset].Points[0]) != points {
+				t.Errorf("error, time since last append: %v, last offset: %v", totalTs, lastOffset)
+			}
+			lastOffset = offset
+		}
+	}
+}
+
+func TestRollingPolicy_Add(t *testing.T) {
+	rand.Seed(time.Now().Unix())
+
+	table := []map[string][]int{
+		{
+			"timeSleep":       []int{299, 2},
+			"offsetAndPoints": []int{0, 1, 1, 1},
+		},
+		{
+			"timeSleep":       []int{294, 7, 600},
+			"offsetAndPoints": []int{0, 1, 1, 1, 3, 1},
+		},
+		{
+			"timeSleep":       []int{294, 3200},
+			"offsetAndPoints": []int{0, 1, 0, 1},
+		},
+		{
+			"timeSleep":       []int{305, 3200, 6400},
+			"offsetAndPoints": []int{1, 1, 1, 1, 1, 1},
+		},
+	}
+
+	Handler(t, table)
+}


### PR DESCRIPTION
There would be a problem if update the lastAppendTime to time.Now() after a token was filled into a bucket. Specifically, assuming the bucket duration is 300ms, if I call the MarkSuccess at 400ms and 601ms, what we expect is that the second and third bucket will be filled with one token respectively, however, there will be two tokens filled into the second bucket.  

Following is my test code:  
```go
package kratos

import (
	"github.com/bilibili/kratos/pkg/net/netutil/breaker"
	"testing"
	"time"
)

func TestBreaker(t *testing.T) {
	brkGroup := breaker.NewGroup(&breaker.Config{})
	brk := brkGroup.Get("name")

	time.Sleep(400 * time.Millisecond)
	brk.MarkSuccess()
	time.Sleep(201 * time.Millisecond)
	brk.MarkSuccess()

}
```
Print the bucket points after each MarkSuccess:  
```go
func (r *RollingPolicy) add(f func(offset int, val float64), val float64) {
	r.mu.Lock()
	timespan := r.timespan()
	if timespan > 0 {
		offset := r.offset
		// reset the expired buckets
		s := offset + 1
		e, e1 := s+timespan, 0 // e: reset offset must start from offset+1
		if e > r.size {
			e1 = e - r.size
			e = r.size
		}
		for i := s; i < e; i++ {
			r.window.ResetBucket(i)
			offset = i
		}
		for i := 0; i < e1; i++ {
			r.window.ResetBucket(i)
			offset = i
		}
		r.offset = offset
		r.lastAppendTime = time.Now()
	}
	f(r.offset, val)
	r.mu.Unlock()

	fmt.Println("*****buckets*****")
	for _, b := range r.window.window {
		fmt.Println(b.Points)
	}
}
```

The result is:  
```go
=== RUN   TestBreaker
*****buckets*****
[]
[1]
[]
[]
[]
[]
[]
[]
[]
[]
*****buckets*****
[]
[2]
[]
[]
[]
[]
[]
[]
[]
[]
```
