### PR TITLE
修复安装kratos工具包时出现编译的错误

### DIFF
--- a/tool/kratos/build.go
+++ b/tool/kratos/build.go
@@ -16,7 +16,7 @@ func buildAction(c *cli.Context) error {
 	if err != nil {
 		panic(err)
 	}
-	args := append([]string{"build"}, c.Args()...)
+	args := append([]string{"build"}, c.Args().Slice()...)
 	cmd := exec.Command("go", args...)
 	cmd.Dir = buildDir(base, "cmd", 5)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
错误如下：
```shell
go get github.com/bilibili/kratos/tool/kratos
# github.com/bilibili/kratos/tool/kratos
F:\golang\src\github.com\bilibili\kratos\tool\kratos\build.go:19:16: cannot use c.Args() (type cli.Args) as type []string in append
F:\golang\src\github.com\bilibili\kratos\tool\kratos\main.go:15:15: cannot use []cli.Command literal (type []cli.Command) as type []*cli.Command in assignment
F:\golang\src\github.com\bilibili\kratos\tool\kratos\main.go:64:45: cannot use ctx.Args() (type cli.Args) as type []string in argument to installAndRun
F:\golang\src\github.com\bilibili\kratos\tool\kratos\run.go:19:16: cannot use c.Args() (type cli.Args) as type []string in append
F:\golang\src\github.com\bilibili\kratos\tool\kratos\tool.go:74:41: cannot slice c.Args() (type cli.Args)
```
由于c.Args()返回一个接口，所以不能使用append添加到[]string切片中，所以需要使用c.Args().Slice()转换成[]string切片。