### PR TITLE
fix log rotate bug

### DIFF
--- a/pkg/log/internal/filewriter/filewriter.go
+++ b/pkg/log/internal/filewriter/filewriter.go
@@ -274,9 +274,7 @@ func (f *FileWriter) Close() error {
 
 func (f *FileWriter) checkRotate(t time.Time) {
 	formatFname := func(format string, num int) string {
-		if num == 0 {
-			return fmt.Sprintf("%s.%s", f.fname, format)
-		}
+		num++
 		return fmt.Sprintf("%s.%s.%03d", f.fname, format, num)
 	}
 	format := t.Format(f.opt.RotateFormat)


### PR DESCRIPTION
num++的原因是如果原来有个laravel.2012-02-02.001.log 并且里面已经写了一些日志，
在当天程序重启后，FileWriter的lastSplitNum会指向001.log，此时如果再次发生rotate，新生成的存档也会命名为001.log，覆盖了原来001.log里面的日志。go test已通过