### PR TITLE
修复windows下无法识别到已安装的tool且每次使用tool都会重新安装

### DIFF
--- a/tool/kratos/tool.go
+++ b/tool/kratos/tool.go
@@ -180,6 +180,9 @@ func (t Tool) toolPath() string {
 		name = t.Name
 	}
 	gobin := Getenv("GOBIN")
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
 	if gobin != "" {
 		return filepath.Join(gobin, name)
 	}


### PR DESCRIPTION
windows下每次使用tool都会重新使用go get来重新安装，且kratos tool无法识别到已安装的tool。
原因是判断tool是否安装是根据文件是否存在来判断的，但是windows下bin目录的可执行文件是.exe结尾的。。。
https://github.com/bilibili/kratos/blob/7c946dc919c172276e8dbfa706c969ff7033aead/tool/kratos/tool.go#L189-L192

https://github.com/bilibili/kratos/blob/7c946dc919c172276e8dbfa706c969ff7033aead/tool/kratos/tool.go#L177-L187