### PR TITLE
fix: server start error return

### DIFF
--- a/pkg/net/http/blademaster/server.go
+++ b/pkg/net/http/blademaster/server.go
@@ -91,8 +91,7 @@ func (engine *Engine) Start() error {
 	conf := engine.conf
 	l, err := net.Listen(conf.Network, conf.Addr)
 	if err != nil {
-		errors.Wrapf(err, "blademaster: listen tcp: %s", conf.Addr)
-		return err
+		return errors.Wrapf(err, "blademaster: listen tcp: %s", conf.Addr)
 	}
 
 	log.Info("blademaster: start http listen addr: %s", conf.Addr)


### PR DESCRIPTION
server Start method, using errors.Wrapf without return the error